### PR TITLE
fix: WB-3639, add get Shares util method

### DIFF
--- a/src/shares.utils.ts
+++ b/src/shares.utils.ts
@@ -15,3 +15,11 @@ export function shareFile(
     headers,
   });
 }
+
+export function getShares(fileId: string): Shares {
+  const headers = getHeaders();
+  let res = http.get(`${rootUrl}/workspace/share/json/${fileId}?search=`, {
+    headers,
+  });
+  return JSON.parse(<string>res.body);
+}


### PR DESCRIPTION
Adding an util method to retrieve share rights of a document in workspace.